### PR TITLE
Updated to use latest Sphinx version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:2.4.4
+FROM sphinxdoc/sphinx:3.4.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 


### PR DESCRIPTION
Unsure if this will break for some users. If not accepted, I recommend at least creating a new release with version 3 so that users may do:

```
uses: synchronizing/sphinx-action@v3
```