### PR TITLE
Controlled apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:2.4.4
+FROM sphinxdoc/sphinx:latest
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,17 @@ inputs:
       dependencies, for example with
       "apt-get update -y && apt-get install -y perl"
     required: false
+  update:
+    description:
+      Set this flag to run 'apt update' in the container before starting
+      the sphinx build.
+    required: false
+    default: false
+  install:
+    description:
+      A list of additional 'apt' packages to install before running
+      sphinx. (Setting this will force-enable 'update' as well.)
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,13 +1,35 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -u
 import os
 import json
+import subprocess
+import sys
 from sphinx_action import action
 
 # This is the entrypoint called by Github when our action is run. All the
 # Github specific setup is done here to make it easy to test the action code
 # in isolation.
+
+def interpret_env(env_var):
+    if isinstance(env_var, str):
+        return env_var.lower() not in ["false", "no", "off" "0"]
+    return bool(env_var)
+
 if __name__ == "__main__":
     print("[sphinx-action] Starting sphinx-action build.")
+
+    update = os.environ.get("INPUT_UPDATE", False)
+    should_update = interpret_env(update)
+
+    install = os.environ.get("INPUT_INSTALL", "")
+    packages = install.split()
+
+    if should_update or packages:
+        print("Updating apt...")
+        subprocess.call(["/usr/bin/apt", "-y", "update"])
+
+    print(f"{len(packages)} packages (plus dependencies) to install")
+    if packages:
+        subprocess.call(["/usr/bin/apt", "-y", "install", *packages])
 
     if "INPUT_PRE-BUILD-COMMAND" in os.environ:
         pre_command = os.environ["INPUT_PRE-BUILD-COMMAND"]


### PR DESCRIPTION
This PR contains changes to mitigate the issues updating / running `apt` in the container, as discussed in #33.

It turns out that running arbitrary scripts using `os.system()` works... not so well, in practice. So, this PR moves to a more controlled method of managing the container's packages, with two new `with:` options added to the action syntax:

```yml
- uses: ammaraskar/sphinx-action:master
  with:
    update: (true/false, defaults 'false' unless 'install' is set)
    install: >-
      a
      list
      of apt packages
      to install
    docs-folder: docs/
```
The added logic goes:
1. If either 'update' or 'install' is set, update apt with
    ```python3
    subprocess.call(["/usr/bin/apt", "-y", "update"])
    ```
2. Collect the list of packages from 'install'. (`actions.yml` doesn't take yaml sequences directly, but the funky `>-` syntax tells it to fold newlines into spaces and present the results as a single space-separated list.)
3. If the list is non-empty, install them with
    ```python3
    subprocess.call(["/usr/bin/apt", "-y", "install", *packages])
    ```

The PR also makes two other changes:
* Builds the container from `sphinxdoc/sphinx:latest`, because `2.4.4` is **ancient** which is part of the problem. (If people have concerns about tracking a moving-target like `latest`, the current is `4.3.2` and would be a better choice than `2.4.4`.)
* Makes the Python process that runs `entrypoint.py` unbuffered via `#!/usr/bin/env -S python3 -u`, so that the output of `print()` calls and subcommands is more correctly interleaved.

Fixes #33