### PR TITLE
Update sphinx to 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.7"
 install:
-  - pip install sphinx==2.2.0
+  - pip install sphinx==3.0
   - pip install black codecov coverage
 script:
   - black --check entrypoint.py sphinx_action tests


### PR DESCRIPTION
Latest numpydocs (and other packages I'm sure) are requiring Sphinx 3.0