### PR TITLE
Feat/sphinx synch

### DIFF
--- a/.github/workflows/synchronize.yaml
+++ b/.github/workflows/synchronize.yaml
@@ -1,0 +1,18 @@
+name: Daily check for new Sphinx dockers to build against.
+
+on:
+  schedule:
+    # Runs at midnight UTC every day.
+    - cron:  '0 0 * * *'
+
+jobs:
+  run-shell-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run a shell script
+        run: |
+          ./bin/tryrelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.5.2
+FROM sphinxdoc/sphinx:3.5.3
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.1.2
+FROM sphinxdoc/sphinx:3.2.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.1.1
+FROM sphinxdoc/sphinx:3.1.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.2.1
+FROM sphinxdoc/sphinx:3.3.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.2.1
+FROM sphinxdoc/sphinx:7.0.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.3.0
+FROM sphinxdoc/sphinx:4.3.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.3.0
+FROM sphinxdoc/sphinx:6.0.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.1.0
+FROM sphinxdoc/sphinx:4.1.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.1.0
+FROM sphinxdoc/sphinx:6.1.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.4.1
+FROM sphinxdoc/sphinx:3.4.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.3.1
+FROM sphinxdoc/sphinx:4.3.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:7.0.0
+FROM sphinxdoc/sphinx:7.0.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.1.3
+FROM sphinxdoc/sphinx:6.2.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.5.0
+FROM sphinxdoc/sphinx:5.0.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.4.2
+FROM sphinxdoc/sphinx:3.4.3
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:2.4.4
+FROM sphinxdoc/sphinx:3.0.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.0.0
+FROM sphinxdoc/sphinx:3.0.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.0.1
+FROM sphinxdoc/sphinx:4.0.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.2.2
+FROM sphinxdoc/sphinx:5.3.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.0.3
+FROM sphinxdoc/sphinx:3.0.4
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:2.4.4
+FROM sphinxdoc/sphinx:2.4.3
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.5.3
+FROM sphinxdoc/sphinx:3.5.4
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.4.3
+FROM sphinxdoc/sphinx:3.5.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:7.0.1
+FROM sphinxdoc/sphinx:7.1.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.0.2
+FROM sphinxdoc/sphinx:5.1.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.0.1
+FROM sphinxdoc/sphinx:6.1.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.2.0
+FROM sphinxdoc/sphinx:6.2.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.1.2
+FROM sphinxdoc/sphinx:6.1.3
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.0.2
+FROM sphinxdoc/sphinx:4.0.3
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.4.0
+FROM sphinxdoc/sphinx:3.4.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.2.1
+FROM sphinxdoc/sphinx:5.2.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:7.1.1
+FROM sphinxdoc/sphinx:7.1.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.1.2
+FROM sphinxdoc/sphinx:4.2.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.5.4
+FROM sphinxdoc/sphinx:4.0.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:7.1.0
+FROM sphinxdoc/sphinx:7.1.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.0.2
+FROM sphinxdoc/sphinx:3.0.3
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.0.1
+FROM sphinxdoc/sphinx:3.0.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.0.3
+FROM sphinxdoc/sphinx:4.1.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.0.4
+FROM sphinxdoc/sphinx:3.1.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.1.0
+FROM sphinxdoc/sphinx:5.1.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.0.0
+FROM sphinxdoc/sphinx:6.0.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.1.0
+FROM sphinxdoc/sphinx:3.1.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.3.2
+FROM sphinxdoc/sphinx:4.4.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:6.1.1
+FROM sphinxdoc/sphinx:6.1.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.0.0
+FROM sphinxdoc/sphinx:5.0.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.3.1
+FROM sphinxdoc/sphinx:3.4.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.3.0
+FROM sphinxdoc/sphinx:3.3.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.1.1
+FROM sphinxdoc/sphinx:4.1.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.2.0
+FROM sphinxdoc/sphinx:3.2.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.2.0
+FROM sphinxdoc/sphinx:4.3.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.5.1
+FROM sphinxdoc/sphinx:3.5.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.0.0
+FROM sphinxdoc/sphinx:4.0.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.0.1
+FROM sphinxdoc/sphinx:5.0.2
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:3.5.0
+FROM sphinxdoc/sphinx:3.5.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:2.4.3
+FROM sphinxdoc/sphinx:2.4.4
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.2.0
+FROM sphinxdoc/sphinx:5.2.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:4.4.0
+FROM sphinxdoc/sphinx:4.5.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:5.1.1
+FROM sphinxdoc/sphinx:5.2.0
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ jobs:
         docs-folder: "docs/"
 ```
 
+* You can choose a Sphinx version by using the appropriate tag. For example, to
+  specify Sphinx 7.0.0 you would use `ammaraskar/sphinx-action@7.0.0`. `master`
+  currently uses Sphinx 2.4.4.
+
 * If you have any Python dependencies that your project needs (themes, 
 build tools, etc) then place them in a requirements.txt file inside your docs
 folder.

--- a/bin/tryrelease
+++ b/bin/tryrelease
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+DOCKERFILE="Dockerfile"
+: ${RUNNER_TEMP:=/tmp}
+
+
+fetch_current_tags() {
+  gh api repos/:owner/:repo/git/refs/tags \
+    --jq '.[]' -q '.[] | .ref' | 
+    cut -d'/' -f3 |
+    sort
+}
+
+fetch_sphinx_image_tags() {
+  gh api repos/sphinx-doc/sphinx-docker-images/git/refs/tags \
+    --jq '.[]' -q '.[] | .ref' | 
+    cut -d'/' -f3 |
+    sort
+}
+
+NEW_TAGS="${RUNNER_TEMP}/new_tags.txt"
+comm -13 <(fetch_current_tags) <(fetch_sphinx_image_tags) > "$NEW_TAGS"
+if [ ! -s "$NEW_TAGS" ]; then
+    echo "No new tags found."
+    exit 0
+fi
+
+while IFS= read -r tag; do
+    sed -i "1s#.*#FROM sphinxdoc/sphinx:${tag}#g" "$DOCKERFILE"
+
+    git add "$DOCKERFILE"
+    git commit --message "build(release): release version ${tag}"
+    git tag "$tag" 
+    git push --tags
+done < "$NEW_TAGS"
+
+rm "$NEW_TAGS"
+


### PR DESCRIPTION
Adds a commit for each version of the sphinx docker image.

Users just need to point to the commit or tag they want to use. For instance, I tested a sphinx 7.0.0 build with:
```
 - uses: nicholasphair/sphinx-action@7.0.0
    with:
      docs-folder: "docs/"
```

Also adds a daily workflow to compare against the latest release of the [sphinx docker](https://github.com/sphinx-doc/sphinx-docker-images) and crafts a new commit+tag object that uses it.

Relevant to any issue asking for a newer version.