### PR TITLE
The apt-get update command requires --allow-releaseinfo-change

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ build, you can use the `pre-build-command` argument like so:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs2/"
-        pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
+        pre-build-command: "apt-get --allow-releaseinfo-change update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
         build-command: "make latexpdf"
 ```
 


### PR DESCRIPTION
This PR updates the README to describe a successful installation of system level dependencies.

I expect this improvement to solve the issues #33 and #53 because I had a similar issue that is solved by this PR.

**Background:** When running `apt-get update -y && apt-get install -y git`, I obtained the following error messages, hinting at a problem with release info changes.

```
Reading package lists...
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldoldstable'
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldoldstable-updates'
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldoldstable'
```

By adding `--allow-releaseinfo-change` to `apt-get update`, this problem is now solved and system level dependencies are correctly installed.

Similar issues have been solved in the same way [elsewhere](https://github.com/roundcube/roundcubemail-docker/issues/143#issuecomment-944517681).