### PR TITLE
add devs synch tooling without commit history

### DIFF
--- a/.github/workflows/synchronize.yaml
+++ b/.github/workflows/synchronize.yaml
@@ -1,0 +1,19 @@
+name: Daily check for new Sphinx dockers to build against.
+
+on:
+  schedule:
+    # Runs at midnight UTC every day.
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-shell-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run a shell script
+        run: |
+          ./bin/tryrelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ jobs:
         docs-folder: "docs/"
 ```
 
+* You can choose a Sphinx version by using the appropriate tag. For example, to
+  specify Sphinx 7.0.0 you would use `ammaraskar/sphinx-action@7.0.0`. `master`
+  currently uses Sphinx 2.4.4.
+
 * If you have any Python dependencies that your project needs (themes, 
 build tools, etc) then place them in a requirements.txt file inside your docs
 folder.

--- a/bin/tryrelease
+++ b/bin/tryrelease
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+DOCKERFILE="Dockerfile"
+: ${RUNNER_TEMP:=/tmp}
+
+
+fetch_current_tags() {
+  gh api repos/:owner/:repo/git/refs/tags \
+    --jq '.[]' -q '.[] | .ref' | 
+    cut -d'/' -f3 |
+    sort
+}
+
+fetch_sphinx_image_tags() {
+  gh api repos/sphinx-doc/sphinx-docker-images/git/refs/tags \
+    --jq '.[]' -q '.[] | .ref' | 
+    cut -d'/' -f3 |
+    sort
+}
+
+NEW_TAGS="${RUNNER_TEMP}/new_tags.txt"
+comm -13 <(fetch_current_tags) <(fetch_sphinx_image_tags) > "$NEW_TAGS"
+if [ ! -s "$NEW_TAGS" ]; then
+    echo "No new tags found."
+    exit 0
+fi
+
+while IFS= read -r tag; do
+    sed -i "1s#.*#FROM sphinxdoc/sphinx:${tag}#g" "$DOCKERFILE"
+
+    git add "$DOCKERFILE"
+    git commit --message "build(release): release version ${tag}"
+    git tag "$tag" 
+    git push --tags
+done < "$NEW_TAGS"
+
+rm "$NEW_TAGS"
+


### PR DESCRIPTION
Adds tooling for keeping repo in synch with sphinx upstream. Same as dev branch but without the history of tagged releases. This keeps master pinned where it is.