### PR TITLE
Use docker-container-action with build-args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM sphinxdoc/sphinx:2.4.4
+ARG SPHINX_TAG=latest
+FROM sphinxdoc/sphinx:${SPHINX_TAG}
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+        sphinx-tag: "latest"
 ```
 
 * If you have any Python dependencies that your project needs (themes, 
@@ -42,6 +43,9 @@ folder.
 
 * If you have multiple sphinx documentation folders, please use multiple
   `uses` blocks.
+
+* If you wish to use a specific version of Sphinx, edit the `sphinx-tag` line in the configuration
+above.
 
 For a full example repo using this action including advanced usage, take a look
 at https://github.com/ammaraskar/sphinx-action-test

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,11 @@ inputs:
       The folder containing your sphinx docs.
     required: true
     default: "docs/"
+  sphinx-tag:
+    description:
+      The tag to use for sphinxdoc/sphinx.
+    required: false
+    default: "2.4.4"
   build-command:
     description:
       The command used to build your documentation.
@@ -22,5 +27,18 @@ inputs:
       "apt-get update -y && apt-get install -y perl"
     required: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: 'composite'
+  steps:
+    - id: github
+      name: Infer GitHub action repository and ref from GitHub action path
+      uses: pl-strflt/docker-container-action/.github/actions/github@v1
+    - uses: pl-strflt/docker-container-action@v1
+      env:
+        INPUT_DOCS-FOLDER: ${{ inputs.docs-folder }}
+        INPUT_BUILD-COMMAND: ${{ inputs.build-command }}
+        INPUT_PRE-BUILD-COMMAND: ${{ inputs.pre-build-command }}
+      with:
+        repository: ${{ steps.github.outputs.action_repository }}
+        ref: ${{ steps.github.outputs.action_ref }}
+        build-args: |
+          SPHINX_TAG:${{ inputs.sphinx-tag }}

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
   steps:
     - id: github
       name: Infer GitHub action repository and ref from GitHub action path
-      uses: pl-strflt/docker-container-action/.github/actions/github@v1
-    - uses: pl-strflt/docker-container-action@v1
+      uses: ipdxco/docker-container-action/.github/actions/github@v1
+    - uses: ipdxco/docker-container-action@v1
       env:
         INPUT_DOCS-FOLDER: ${{ inputs.docs-folder }}
         INPUT_BUILD-COMMAND: ${{ inputs.build-command }}

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -11,8 +11,9 @@ if __name__ == "__main__":
 
     if "INPUT_PRE-BUILD-COMMAND" in os.environ:
         pre_command = os.environ["INPUT_PRE-BUILD-COMMAND"]
-        print("Running: {}".format(pre_command))
-        os.system(pre_command)
+        if len (pre_command) > 0:  # Check for empty string
+            print("Running: {}".format(pre_command))
+            os.system(pre_command)
 
     github_env = action.GithubEnvironment(
         build_command=os.environ.get("INPUT_BUILD-COMMAND"),


### PR DESCRIPTION
This implements my suggested change in #57.  An `ARG` line is added to the `Dockerfile` to represent the Sphinx version.  The `action.yml` file is edited to use [Docker Container Action](https://github.com/pl-strflt/docker-container-action) as GitHub's own offering lacks the required `build-args` feature.

A new input `sphinx-tag` is added, defaulting to "2.4.4" for compatibility with the current `master` behavior.

Note that the `synchronize` workflow should no longer be needed, nor the dozens of tags in this repo.